### PR TITLE
add local tag for local Docker build

### DIFF
--- a/docker/README.txt
+++ b/docker/README.txt
@@ -1,8 +1,8 @@
 To build, run these docker commands from the terminal.
 
-docker build -t edr10 .
+docker build -t edr10:local .
 
-docker run -p 9090:8080/tcp edr10
+docker run -p 9090:8080/tcp edr10:local
 
 Ignore the Errors/Exceptions at startup
 


### PR DESCRIPTION
Qualifying the Docker image with a `:local` suffix prevents (for me) issues with searching the image on Docker Hub.  Feel free to close/ignore if not valuable for others.