### PR TITLE
Migrate Geotk dependency to Apache SIS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
   <properties>
     <ets-code>ogcapi-edr10</ets-code>
     <spec-version>1.0</spec-version>
-    <geotk.version>3.21</geotk.version>
     <docker.teamengine.version>5.4</docker.teamengine.version>
   </properties>
 
@@ -67,7 +66,7 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.5.1</version>
+      <version>5.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.reprezen.kaizen</groupId>
@@ -77,7 +76,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.0</version>
+      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -90,61 +89,37 @@
     <dependency>
       <groupId>net.jadler</groupId>
       <artifactId>jadler-core</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.jadler</groupId>
       <artifactId>jadler-jetty</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.1</version>
       <scope>test</scope>
     </dependency>
-<dependency>
-    <groupId>javax.xml.bind</groupId>
-    <artifactId>jaxb-api</artifactId>
-    <version>2.3.1</version>
-</dependency>
-<!-- https://mvnrepository.com/artifact/org.opengis/geoapi -->
-<dependency>
-    <groupId>org.opengis</groupId>
-    <artifactId>geoapi-pending</artifactId>
-    <version>3.1-M04</version>
-</dependency>
-
-<dependency>
-	<groupId>com.github.erosb</groupId>
-	<artifactId>everit-json-schema</artifactId>
-	<version>1.14.1</version>
-</dependency>
-
     <dependency>
-      <groupId>org.geotoolkit</groupId>
-      <artifactId>geotk-utility</artifactId>
-      <version>3.21</version>
+      <groupId>com.github.erosb</groupId>
+      <artifactId>everit-json-schema</artifactId>
+      <version>1.14.4</version>
     </dependency>
     <dependency>
-      <groupId>org.geotoolkit</groupId>
-      <artifactId>geotk-referencing</artifactId>
-      <version>3.21</version>
+      <groupId>org.apache.sis.core</groupId>
+      <artifactId>sis-referencing</artifactId>
+      <version>1.4</version>
     </dependency>
     <dependency>
-      <groupId>org.geotoolkit.pending</groupId>
-      <artifactId>geotk-geometry</artifactId>
-      <version>3.21</version>
+      <groupId>org.apache.sis.non-free</groupId>
+      <artifactId>sis-embedded-data</artifactId>
+      <version>1.4</version>
     </dependency>
-    <dependency>
-      <groupId>org.geotoolkit.pending</groupId>
-      <artifactId>geotk-temporal</artifactId>
-      <version>3.21</version>
-    </dependency>
-
   </dependencies>
 
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.4</version>
+        <version>3.6.3</version>
         <configuration>
           <source>8</source>
           <docfilessubdirs>true</docfilessubdirs>
@@ -196,7 +171,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>3.0.1</version>
         <configuration>
           <autoVersionSubmodules>true</autoVersionSubmodules>
           <tagNameFormat>@{project.version}</tagNameFormat>
@@ -206,7 +181,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.12.1</version>
         <executions>
           <execution>
             <id>site-package</id>
@@ -234,7 +209,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-scm-publish-plugin</artifactId>
-        <version>1.1</version>
+        <version>3.2.1</version>
         <configuration>
           <scmBranch>gh-pages</scmBranch>
         </configuration>
@@ -245,7 +220,7 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.28.0</version>
+          <version>0.43.4</version>
           <configuration>
             <images>
               <image>
@@ -288,7 +263,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.6.1</version>
           <configuration>
             <artifactItems>
               <artifactItem>
@@ -325,7 +300,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.0</version>
+            <version>3.2.5</version>
             <executions>
               <execution>
                 <goals>
@@ -379,7 +354,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -400,15 +375,6 @@
       </build>
     </profile>
   </profiles>
-  
-<repositories>
-  <repository>
-    <id>geotoolkit</id>
-    <name>Geotk Modules</name>
-    <url>http://maven.geotoolkit.org</url>
-    <layout>default</layout>
-  </repository>
-</repositories>
 
   <distributionManagement>
     <repository>

--- a/src/main/java/org/opengis/cite/ogcapiedr10/corecollections/CollectionsResponse.java
+++ b/src/main/java/org/opengis/cite/ogcapiedr10/corecollections/CollectionsResponse.java
@@ -29,13 +29,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import org.geotoolkit.referencing.CRS;
-import org.geotoolkit.referencing.crs.DefaultGeographicCRS;
+import org.apache.sis.referencing.CRS;
 import org.opengis.cite.ogcapiedr10.CommonFixture;
 import org.opengis.cite.ogcapiedr10.openapi3.TestPoint;
 import org.opengis.cite.ogcapiedr10.openapi3.UriBuilder;
 import org.opengis.cite.ogcapiedr10.util.TemporalExtent;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.crs.GeographicCRS;
 import org.testng.ITestContext;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -240,13 +240,13 @@ public class CollectionsResponse extends CommonFixture {
 
 			try {
 
-				source = CRS.parseWKT(crsMap.get("wkt").toString());
+				source = CRS.fromWKT(crsMap.get("wkt").toString());
 			} catch (Exception e) {
 
 				e.printStackTrace();
 			}
 
-			DefaultGeographicCRS crs = (DefaultGeographicCRS) source;
+			GeographicCRS crs = (GeographicCRS) source;
 
 			if (crs.getDatum().getEllipsoid().getName().toString().equals("WGS 84")
 					|| crs.getDatum().getEllipsoid().getName().toString().equals("WGS_1984")


### PR DESCRIPTION
Note: contrarily to `geomatics-geotk`, this pull request uses the approved OGC GeoAPI release and official Apache SIS 1.4. This is possible because `ets-ogcapi-edr10 ` do not use the Geotk GML services. If there is a need to put `geomatics-geotk` and `ets-ogcapi-edr10 ` in the same project, their dependency versions will need to be aligned first.